### PR TITLE
variant allele freq and multi-mapping read annotations

### DIFF
--- a/ctat_mutations
+++ b/ctat_mutations
@@ -486,11 +486,12 @@ class RnaseqSnp:
                                             "-plots", str_recalibration_plots_pdf])
                 lcmd_gatk_recalibration_commands.append(Command(str_cur_command,'analyze_covariate.ok'))
         
-        return (lcmd_gatk_recalibration_commands, str_return_bam, str_return_bai)
+        return (lcmd_gatk_recalibration_commands, str_return_bam, str_return_bai, str_dedupped_bam) # end of RNA_refine_mapping()
     
 
     def Variant_Calling_GATK_HaplotypeCaller(self,
-                                             str_align_bam_file):
+                                             str_bam_for_var_calling,
+                                             str_bam_for_var_annotation):
                 
 
         # Commands which will be returned
@@ -505,7 +506,7 @@ class RnaseqSnp:
         gatk_HaplotypeCaller_core_cmd = " ".join(["java", "-jar", self.gatk_path,
                                                   "HaplotypeCaller",
                                                   "-R", self.genome_fa,
-                                                  "-I", str_align_bam_file,
+                                                  "-I", str_bam_for_var_calling,
                                                   "--recover-dangling-heads","true",
                                                   "--dont-use-soft-clipped-bases",
                                                   "-stand-call-conf", "20.0" ]) # just missing -O output_vcf_file
@@ -528,7 +529,7 @@ class RnaseqSnp:
         ## annotate
         (lcmd_gatk_variants_command, str_variants_file) = self.annotate_variants(lcmd_gatk_variants_commands,
                                                                                  str_variants_file,
-                                                                                 str_align_bam_file)
+                                                                                 str_bam_for_var_annotation)
 
         ## Store 'initial' vcf file (pre-annotation filtering) as a primary output
 
@@ -541,7 +542,7 @@ class RnaseqSnp:
             
         (lcmd_gatk_variants_command, str_variants_file) = self.filter_HaplotypeCaller_raw_variants(lcmd_gatk_variants_commands,
                                                                                                    str_variants_file,
-                                                                                                   str_align_bam_file)
+                                                                                                   str_bam_for_var_calling)
         
         return (lcmd_gatk_variants_commands, str_variants_file)
 
@@ -655,8 +656,9 @@ class RnaseqSnp:
     
 
     def Variant_Calling_GATK_Mutect2(self,
-                                     str_align_bam_file):
-                                     
+                                     str_bam_file_for_var_calling,
+                                     str_bam_file_for_var_annotation):
+        
         # Commands which will be returned
         lcmd_gatk_variants_commands = []
                    
@@ -680,7 +682,7 @@ class RnaseqSnp:
             str_m2_call = " ".join(["java", "-jar", self.gatk_path,
                                     "Mutect2",
                                     "-R", self.genome_fa,
-                                    "-I", str_align_bam_file,
+                                    "-I", str_bam_file_for_var_calling,
                                     "--dont-use-soft-clipped-bases",
                                     #"-stand-call-conf","20.0",  # removed as option in latest mutect2?
                                     "-A", "ReferenceBases",
@@ -730,7 +732,7 @@ class RnaseqSnp:
 
             str_variants_file = os.path.join(self.tmp_dir, "Mutect2.BestPractices.raw_variants.vcf")
 
-            mutect2_call_cmdlist, f1r2_tar_gz_list = self.generate_Mutect2_best_practice_cmds(str_align_bam_file=str_align_bam_file,
+            mutect2_call_cmdlist, f1r2_tar_gz_list = self.generate_Mutect2_best_practice_cmds(str_align_bam_file=str_bam_file_for_var_calling,
                                                                                               str_variants_file=str_variants_file)
             lcmd_gatk_variants_commands.extend(mutect2_call_cmdlist)
 
@@ -758,7 +760,7 @@ class RnaseqSnp:
                 # 1. get pileup summaries
                 pileups_output = os.path.join(self.tmp_dir,"tumor.pileups")
 
-                pileup_cmds_list = self.generate_GetPileupSummaries_cmds(str_align_bam_file=str_align_bam_file,
+                pileup_cmds_list = self.generate_GetPileupSummaries_cmds(str_align_bam_file=str_bam_file_for_var_calling,
                                                                          pileups_output=pileups_output)
                 
                 lcmd_gatk_variants_commands.extend(pileup_cmds_list)
@@ -803,7 +805,7 @@ class RnaseqSnp:
             
 
         ## annotate the vcf file.  This stores a primary output file in the out_dir
-        (lcmd_gatk_variants_commands, annotated_vcf) = self.annotate_variants(lcmd_gatk_variants_commands, str_filtered_variants_file, str_align_bam_file)
+        (lcmd_gatk_variants_commands, annotated_vcf) = self.annotate_variants(lcmd_gatk_variants_commands, str_filtered_variants_file, str_bam_file_for_var_annotation)
 
         # provide primary Mutect2 output with annotations:
         
@@ -871,15 +873,19 @@ class RnaseqSnp:
         bam_target_for_var_calling = str_align_file
         bam_target_for_var_calling_bai = str_bai_file
 
+        bam_target_for_var_annotation = bam_target_for_var_calling # needs NH tags for number of hits.  Turns out split-n-cigar removes NH!
+
         if not self.input_vcf_file:
             ## Refine mapping using PICARD unless a vcf file is already provided.
 
             (refine_mapping_cmd,
              bam_target_for_var_calling,
-             bam_target_for_var_calling_bai) = self.RNA_refine_mapping(str_align_file = str_align_file)
+             bam_target_for_var_calling_bai,
+             duplicate_marked_bam) = self.RNA_refine_mapping(str_align_file = str_align_file)
 
             lcmd_commands.extend(refine_mapping_cmd)
 
+            bam_target_for_var_annotation = duplicate_marked_bam
 
         ######################################################################
         ## Variant Calling, Annotation, and Initial Annotation-free Filtering
@@ -893,8 +899,8 @@ class RnaseqSnp:
             lcmd_commands = self.tabix_if_needed(lcmd_commands, variants_vcf_file)
             
             # must add variant annotations:
-            (lcmd_commands, variants_vcf_file) = self.annotate_variants(lcmd_commands, variants_vcf_file, bam_target_for_var_calling)
-
+            (lcmd_commands, variants_vcf_file) = self.annotate_variants(lcmd_commands, variants_vcf_file, bam_target_for_var_annotation)
+            
             # store annotated vcf as primary output:
             variants_wAnnot_vcf = os.path.join(self.out_dir, os.path.basename(self.input_vcf_file) + ".wAnnot.vcf.gz")
             lcmd_commands.append(Command("cp {} {}".format(variants_vcf_file, variants_wAnnot_vcf), "cp_input_vcf_variants_wAnnot.vcf_gz.ok"))
@@ -908,13 +914,15 @@ class RnaseqSnp:
 
             if args_parsed.str_gatk_variant_call_method == STR_GATK_HC:
 
-                (variant_calling_cmd, variants_vcf_file) = self.Variant_Calling_GATK_HaplotypeCaller(str_align_bam_file = bam_target_for_var_calling)
-
+                (variant_calling_cmd, variants_vcf_file) = self.Variant_Calling_GATK_HaplotypeCaller(str_bam_for_var_calling = bam_target_for_var_calling,
+                                                                                                     str_bam_for_var_annotation = bam_target_for_var_annotation)
+                
 
             elif args_parsed.str_gatk_variant_call_method == STR_GATK_MUTECT2:
-
-                (variant_calling_cmd, variants_vcf_file) = self.Variant_Calling_GATK_Mutect2(str_align_bam_file = bam_target_for_var_calling)
-
+                
+                (variant_calling_cmd, variants_vcf_file) = self.Variant_Calling_GATK_Mutect2(str_bam_for_var_calling = bam_target_for_var_calling,
+                                                                                             str_bam_for_var_annotation = bam_target_for_var_annotation)
+                
 
             else:
                 raise RuntimeError("Error, not recognizing variant calling method: {}".format(args_call.str_gatk_variant_call_method))

--- a/ctat_mutations
+++ b/ctat_mutations
@@ -356,9 +356,8 @@ class RnaseqSnp:
                                                              "BAM", "SortedByCoordinate",
                                                              "--twopassMode", "Basic",
                                                              "--limitBAMsortRAM", "30000000000",
-                                                             " --outSAMmapqUnique","60",
-                                                             "--outFileNamePrefix",
-                                                             self.tmp_dir + os.sep])
+                                                             "--outSAMmapqUnique","60",
+                                                             "--outFileNamePrefix", self.tmp_dir + os.sep])
 
         lcmd_commands.append(Command(str_star_align, "star_alignment.ok"))
 

--- a/ctat_mutations
+++ b/ctat_mutations
@@ -1082,8 +1082,9 @@ class RnaseqSnp:
         cmdstr = " ".join([ os.path.join(SCRIPTDIR, "annotate_entropy_n_homopolymers.py"),
                             "--input_vcf", str_target_vcf_file,
                             "--ref_genome_fa", self.genome_fa,
-                            "--output_vcf", homopolymer_annot_vcf ])
-
+                            "--output_vcf", homopolymer_annot_vcf,
+                            "--tmpdir", self.tmp_dir])
+        
         lcmd_commands.append(Command(cmdstr, 'annotate_homopolymers.ok'))
                 
         lcmd_commands = self.tabix_if_needed(lcmd_commands, homopolymer_annot_vcf)
@@ -1099,8 +1100,9 @@ class RnaseqSnp:
         
         cmdstr = " ".join([ os.path.join(SCRIPTDIR, "annotate_exon_splice_proximity.py"),
                             "--input_vcf", str_target_vcf_file,
-                            "--ref_exon_bed", os.path.join(self.ctat_mutation_lib_path, "ref_exons.bed"),
-                            "--output_vcf", splice_dist_annot_vcf ])
+                            "--ctat_mutation_lib_dir", self.ctat_mutation_lib_path,
+                            "--output_vcf", splice_dist_annot_vcf,
+                            "--tmpdir", self.tmp_dir])
 
         lcmd_commands.append(Command(cmdstr, 'annotate_splice_dist.ok'))
                 

--- a/mutation_lib_prep/gencode_gtf_to_splice_adjacent_regions.pl
+++ b/mutation_lib_prep/gencode_gtf_to_splice_adjacent_regions.pl
@@ -1,0 +1,80 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use FindBin;
+use lib ("$FindBin::Bin/PerlLib");
+use Gene_obj;
+use Gene_obj_indexer;
+use GTF_utils;
+
+use Carp;
+
+# gencode_gtf_to_splice_adjacent_regions.pl $CTAT_GENOME_LIB/ref_annot.gtf > ref_annot.splice_adj.bed
+
+my $usage = "usage: $0 file.GTF > file.splice_adjacent.bed\n\n";
+
+my $gtf_file = $ARGV[0] or die $usage;
+my $exon_splice_dist = 10;
+
+main: {
+            
+
+    my %exon_splice_regions;
+    
+
+    my $gene_obj_indexer = {};
+
+    print STDERR "-parsing GTF file: $gtf_file\n";
+    my $asmbl_id_to_gene_list_href = &GTF_utils::index_GTF_gene_objs_from_GTF($gtf_file, $gene_obj_indexer);
+
+    foreach my $asmbl_id (sort keys %$asmbl_id_to_gene_list_href) {
+        
+        my @gene_ids = @{$asmbl_id_to_gene_list_href->{$asmbl_id}};
+        
+        #print "ASMBL: $asmbl_id, gene_ids: @gene_ids\n";
+        
+        foreach my $gene_id (@gene_ids) {
+            
+            my $gene_obj_ref = $gene_obj_indexer->{$gene_id} or die "Error, no gene obj for $gene_id";
+            
+            my @intron_coordinates = $gene_obj_ref->get_intron_coordinates();
+
+            foreach my $coordset (@intron_coordinates) {
+                my ($intron_lend, $intron_rend) = sort {$a<=>$b} @$coordset;
+
+                my $intron_span_left = join(":", $asmbl_id, "L", $intron_lend, $intron_lend + $exon_splice_dist -1);
+
+                my $intron_span_right = join(":", $asmbl_id, "R", $intron_rend - $exon_splice_dist + 1, $intron_rend);
+
+                $exon_splice_regions{$intron_span_left} = { name => $intron_span_left,
+                                                            asmbl_id => $asmbl_id,
+                                                            lend => $intron_lend,
+                                                            rend => $intron_lend + $exon_splice_dist -1,
+                };
+
+                $exon_splice_regions{$intron_span_right} = { name => $intron_span_right,
+                                                             asmbl_id => $asmbl_id,
+                                                             lend => $intron_rend - $exon_splice_dist + 1,
+                                                             rend => $intron_rend,
+                };
+            }
+            
+        }
+    }
+    
+    my @entries = values %exon_splice_regions;
+    
+    @entries = sort {$a->{asmbl_id} cmp $b->{asmbl_id}
+                     ||
+                         $a->{lend} <=> $b->{lend} } @entries;
+
+
+    foreach my $entry (@entries) {
+        print join("\t", $entry->{asmbl_id}, $entry->{lend}, $entry->{rend}, $entry->{name}) . "\n";
+    }
+
+    
+    exit(0);
+}
+

--- a/src/annotate_PASS_reads.py
+++ b/src/annotate_PASS_reads.py
@@ -30,7 +30,9 @@ def processVCFHead(line, outfile):
         VPR : Variant Passed Reads, reads that PASS filtering that contain the variation 
         TPR : Total Passed Reads , reads that PASS filtering 
         TDM : Total Duplicate Marked, number of reads that are duplicate marked
+        VAF: Variant allele fraction 
     '''
+    
     if line[0] == "#":
         if re.match("#CHROM\t", line):
             # add header info line for the repeat annotation type
@@ -39,6 +41,7 @@ def processVCFHead(line, outfile):
             outfile.write("##INFO=<ID=VPR,Number=1,Type=Integer,Description=\"Variant Passed Reads, reads that PASS filtering that contain the variation\">\n")
             outfile.write("##INFO=<ID=TPR,Number=1,Type=Integer,Description=\"Total Passed Reads , reads that PASS filtering\">\n")
             outfile.write("##INFO=<ID=TDM,Number=1,Type=Integer,Description=\"Total Duplicate Marked, number of reads that are duplicate marked \">\n")
+            outfile.write("##INFO=<ID=VAF,Number=1,Type=Float,Description=\"Variant allele fraction (VPR / TPR) \">\n")
 
         outfile.write(line)
 
@@ -80,7 +83,7 @@ def evaluate_PASS_reads(i, bamFile):
 
     vals = i.split("\t")
 
-    sys.stderr.write("[{}]\n".format(vals[0] + "::" + vals[1]))
+    #sys.stderr.write("[{}]\n".format(vals[0] + "::" + vals[1]))
 
     #--------------
     # Constants 
@@ -195,7 +198,8 @@ def evaluate_PASS_reads(i, bamFile):
     line[7] += ";VPR={}".format(newmismatch)
     line[7] += ";TPR={}".format(newcov)
     line[7] += ";TDM={}".format(duplicateMarked)
-
+    line[7] += ";VAF={:0.3f}".format(newmismatch/newcov if newcov > 0 else 0)
+    
     # variant frequency if needed 
     # varfreq = (newmismatch/newcov)
 

--- a/src/annotate_entropy_n_homopolymers.py
+++ b/src/annotate_entropy_n_homopolymers.py
@@ -18,22 +18,38 @@ logger = logging.getLogger(__name__)
 
 
 
-def contains_homopolymer(window_seq, edit_base_nuc):
+def contains_homopolymer(side_window_size, window_seq, ref_base_nuc, edit_base_nuc):
     
     homopolymer = False
 
     window_seq = window_seq.upper()
+    ref_base_nuc = ref_base_nuc.upper()
     edit_base_nuc = edit_base_nuc.upper()
     
     # iterate of the sequence 
     #   check if the 4 consecutive nucleotides are the edited nucleotide 
     #   if true will set th variable homopolymer to TRUE
-    for k in range(len(window_seq)-4):
-        if (edit_base_nuc == window_seq[k] and
-            edit_base_nuc == window_seq[k+1] and
-            edit_base_nuc == window_seq[k+2] and
-            edit_base_nuc == window_seq[k+3] ) :
+    for k in range(len(window_seq)-side_window_size):
 
+
+        ## check edit base
+        all_match_flag = True
+
+        for pos in range(side_window_size):
+            if window_seq[pos] != edit_base_nuc:
+                all_match_flag = False
+
+        if all_match_flag:
+            return True
+
+        ## check ref base
+        all_match_flag = True
+
+        for pos in range(side_window_size):
+            if window_seq[pos] != ref_base_nuc:
+                all_match_flag = False
+
+        if all_match_flag:
             return True
     
     # no homopolymer found
@@ -72,20 +88,27 @@ def main():
         description = "Adds repeat feature annotations to vcf file.\n")
     
     parser.add_argument('--input_vcf', required=True, help="input vcf file")
-    parser.add_argument('--ref_genome_fa', required=True, help='reference  file')
-    parser.add_argument('--output_vcf', required=True, help="output vcf file including annotation for distance to splice neighbor")
-    parser.add_argument("--window_size",  type=int, default=10, help="window length centered at variant position for sequence analysis")
-    
-    parser.add_argument('--debug', default=False, action='store_true', help='debug mode, retains temporary intermediate files')
-    parser.add_argument("--tmpdir", default="/tmp", help="tmp directory")
 
+    parser.add_argument('--ref_genome_fa', required=True, help='reference  file')
+
+    parser.add_argument('--output_vcf', required=True,
+                        help="output vcf file including annotation for distance to splice neighbor")
+
+    parser.add_argument("--side_window_size",  type=int, default=3,
+                        help="a window is centered at the variant position with side_window_size on each side, so window length = (2 * side_window_size) + 1 ")
+    
+    parser.add_argument('--debug', default=False, action='store_true',
+                        help='debug mode, retains temporary intermediate files')
+    
+    parser.add_argument("--tmpdir", default="/tmp", help="tmp directory")
+    
     args = parser.parse_args()
     
 
 
     input_vcf_file = args.input_vcf
     genome_fa_file = args.ref_genome_fa
-    window_size = args.window_size
+    side_window_size = args.side_window_size
     output_vcf_file = args.output_vcf
     DEBUG_MODE = args.debug
 
@@ -94,11 +117,9 @@ def main():
 
     tmpdir = args.tmpdir
 
-    half_window = int(window_size/2.0 + 0.5)
-
     # 1) Create the bed file containing the windowed variants
     #------------------------
-    windowed_variants_bed_file = os.path.join(tmpdir, os.path.basename(input_vcf_file) + ".windowed_{}_variants.bed".format(window_size))
+    windowed_variants_bed_file = os.path.join(tmpdir, os.path.basename(input_vcf_file) + ".windowed_{}_variants.bed".format(2*side_window_size+1))
     with open(windowed_variants_bed_file, 'w') as ofh:
         with ctat_util.open_file_for_reading(input_vcf_file) as fh:
             for line in fh:
@@ -107,20 +128,22 @@ def main():
                 vals = line.split("\t")
                 chr_val = vals[0]
                 chr_coord = int(vals[1])
+                ref_base_nuc = vals[3]
                 edit_base_nuc = vals[4]
                 
-                chrpostoken = "{}:{}:{}".format(chr_val, chr_coord, edit_base_nuc)
+                chrpostoken = "{}:{}:{}:{}".format(chr_val, chr_coord, ref_base_nuc, edit_base_nuc)
                 
-                ofh.write("\t".join([chr_val, str(chr_coord-half_window), str(chr_coord+half_window), chrpostoken]) + "\n")
-
-
+                ofh.write("\t".join([chr_val,
+                                     str(chr_coord - side_window_size - 1),
+                                     str(chr_coord + side_window_size),
+                                     chrpostoken]) + "\n")
 
     ## get fasta coordinates for feature
     window_seqs_file = windowed_variants_bed_file + ".seqs"
     cmd = "fastaFromBed -name -tab -fi {} -bed {} -fo {}".format(genome_fa_file, windowed_variants_bed_file, window_seqs_file)
     logger.info("CMD: {}".format(cmd))
     subprocess.check_call(cmd, shell=True)
-    
+
     chrpos_homopolymer_set = set()
     chrpos_entropy_dict = dict()
 
@@ -131,14 +154,15 @@ def main():
             chrpostoken = vals[0]
             window_seq = vals[1]
             
-            (chrom, position, edit_base_nuc) = chrpostoken.split(":")
+            (chrom, position, ref_base_nuc, edit_base_nuc) = chrpostoken.split(":")
             
             chrpos = "{}:{}".format(chrom, position)
             
             # set the constant homopolymer to false for this line 
-            homopolymer_flag = contains_homopolymer(window_seq, edit_base_nuc)
+            homopolymer_flag = contains_homopolymer(side_window_size, window_seq, ref_base_nuc, edit_base_nuc)
             if homopolymer_flag:
                 chrpos_homopolymer_set.add(chrpos)
+                #print("{}\t{}\tHOMOP".format(window_seq, chrpostoken))
 
             entropy_val = compute_entropy(window_seq)
             chrpos_entropy_dict[chrpos] = entropy_val
@@ -148,7 +172,8 @@ def main():
 
     ###############################################
     ## Add feature annotations to original vcf file
-    
+
+        
     logger.info("Adding entropy and homopolymer annotations")
     ## make output a vcf formatted file:
     with open(output_vcf_file, 'w') as ofh:
@@ -160,7 +185,7 @@ def main():
                     if re.match("#CHROM\t", line):
                         # add header info line for the repeat annotation type
                         ofh.write("##INFO=<ID=Homopolymer,Number=1,Type=Integer,Description=\"Variant is located in or near a homopolymer sequence\">\n")
-                        ofh.write("##INFO=<ID=Entropy,Number=1,Type=Float,Description=\"Entropy for sequence in window of length {} centered at the variant position\">\n".format(window_size))
+                        ofh.write("##INFO=<ID=Entropy,Number=1,Type=Float,Description=\"Entropy for sequence in window of length {} centered at the variant position\">\n".format(2*side_window_size+1))
                         
                     ofh.write(line)
                 else:

--- a/src/annotate_entropy_n_homopolymers.py
+++ b/src/annotate_entropy_n_homopolymers.py
@@ -27,7 +27,7 @@ def contains_homopolymer(side_window_size, window_seq, ref_base_nuc, edit_base_n
     edit_base_nuc = edit_base_nuc.upper()
     
     # iterate of the sequence 
-    #   check if the 4 consecutive nucleotides are the edited nucleotide 
+    #   check if the side_window_size consecutive nucleotides are the edited nucleotide 
     #   if true will set th variable homopolymer to TRUE
     for k in range(len(window_seq)-side_window_size):
 


### PR DESCRIPTION
The updated variant allele frequency is now included as an annotation.

Also, the number and frequency of multi-mapped reads is indicated. Note, this requires using the deplicate-marked bam file for annotation, and separately using the fully recalibrated bam file for variant calling purposes. The split-n-cigar step of the pipeline appears to strip out the NH tags from the bam file, and so to get the number of mappings from the NH tag, we need to leverage the bam (dedupped.bam) before that step.

In the ctat mutations pipeline code, there's now two bam variables, one for variant calling and one for annotation purposes - named accordingly.