### PR TITLE
Update Docker file for compatibility with nextflow

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get --allow-releaseinfo-change update && apt-get -qq -y install --no-ins
     pbzip2 \
     perl \
     pigz \
+    procps \
     unzip \
     wget \
     zlib1g \


### PR DESCRIPTION
Hello, 
first of all, thanks for the great tool. 
The current image of ctat-mutations is not compatible with nextflow due to the lack of the command ps, available in procps. Cheers,
Claudio